### PR TITLE
feat: v3.1.0 — label filtering, UI redesign, statistics persistence, and extension bumps

### DIFF
--- a/packages/iac_device_info_ext/pubspec.yaml
+++ b/packages/iac_device_info_ext/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  in_app_console: ^3.0.0
+  in_app_console: ^3.1.0
   device_info_plus: ^10.0.0
 
 dev_dependencies:

--- a/packages/iac_export_logs_ext/pubspec.yaml
+++ b/packages/iac_export_logs_ext/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_file_dialog: ^3.0.3
   path_provider: ^2.1.5
   share_plus: ^12.0.1
-  in_app_console: ^3.0.0
+  in_app_console: ^3.1.0
   
 dev_dependencies:
   flutter_test:

--- a/packages/iac_network_inspector_ext/pubspec.yaml
+++ b/packages/iac_network_inspector_ext/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  in_app_console: ^3.0.0
+  in_app_console: ^3.1.0
   dio: ^5.9.0
 
 dev_dependencies:

--- a/packages/iac_performance_overlay_ext/pubspec.yaml
+++ b/packages/iac_performance_overlay_ext/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  in_app_console: ^3.0.0
+  in_app_console: ^3.1.0
   shared_preferences: ^2.2.0
 
 dev_dependencies:

--- a/packages/iac_route_tracker_ext/pubspec.yaml
+++ b/packages/iac_route_tracker_ext/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  in_app_console: ^3.0.0
+  in_app_console: ^3.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/iac_statistics_ext/pubspec.yaml
+++ b/packages/iac_statistics_ext/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  in_app_console: ^3.0.0
+  in_app_console: ^3.1.0
   path_provider: ^2.1.5
 
 dev_dependencies:


### PR DESCRIPTION
## Summary

- **Label filtering** — loggers can now call `setLabel()` to tag messages; the console UI exposes a filter sheet to show/hide per-module logs, and labels are tracked in insertion order with deduplication
- **UI redesign** — refreshed console screen, extensions screen, and all extension widgets (network inspector, route tracker, device info, export logs, performance overlay, statistics)
- **Statistics persistence** — `iac_statistics_ext` now saves log history to device storage (capped at 500 entries) and survives app restarts; includes TF-IDF and pattern-based duplicate grouping
- **Extension version bumps** — all extensions bumped to `2.1.0` (or `1.1.0` for performance overlay) with `in_app_console` constraint updated to `^3.1.0`
- **Docs** — README image URLs updated to latest commit SHA across all packages; `iac_statistics_ext` screenshot added

## Test plan

- [ ] `flutter test` passes with new label management tests
- [ ] Label filter sheet appears and filters logs correctly per module
- [ ] Statistics persist across app restarts
- [ ] All extension UIs render correctly after redesign
- [ ] `flutter pub publish --dry-run` passes for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)